### PR TITLE
feat: declare support for php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^5.1 || ^7.0.1"


### PR DESCRIPTION
Hello :wave: 

We are dropping PHP 7.4 support for Nextcloud Mail. 

	"config": {
		"platform": {
			"php": "8.0"
		},
	},

The above change to our composer.json break the installation of gravatarphp:

> Problem 1
>     - Root composer.json requires gravatarphp/gravatar ^2.0 -> satisfiable by gravatarphp/gravatar[v2.0.0].
>     - gravatarphp/gravatar v2.0.0 requires php ^7.1 -> your php version (8.0; overridden via config.platform, actual: 8.2.0) does not satisfy that requirement.

`>= 7.1` should also work (cf. https://semver.madewithlove.com/?package=php&constraint=%3E%3D7.1&stability=stable) but somehow it dont :man_shrugging: 

This patch change the version constraint to make it work. 